### PR TITLE
Explicitly include limits header

### DIFF
--- a/source/src/node/buffer/buffer-player.cpp
+++ b/source/src/node/buffer/buffer-player.cpp
@@ -2,6 +2,7 @@
 #include "signalflow/node/buffer/buffer-player.h"
 
 #include <stdlib.h>
+#include <limits>
 
 namespace signalflow
 {


### PR DESCRIPTION
Fixes an issue I hit, similar to [this one](https://github.com/MultiMC/MultiMC5/issues/3574) while compiling.

FYI my gcc is ``gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0``