### PR TITLE
Enable building on intel mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_MACOSX_RPATH 1)
 # environmental variable CMAKE_OSX_ARCHITECTURES.
 #-------------------------------------------------------------------------------
 if (NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+    set(CMAKE_OSX_ARCHITECTURES "${ARCHS_STANDARD}")
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Specifying arm64 causes builds to fail on intel macs. With `ARCHS_STANDARD` CMake will make a Universal build by
default, but will work on intel macs.
