### PR TITLE
Fix macOS universal Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,14 @@
 cmake_minimum_required(VERSION 3.12.0)
+
+#-------------------------------------------------------------------------------
+# By default, build a universal library on Apple.
+# For a faster build, select a single architecture by defining the
+# environmental variable CMAKE_OSX_ARCHITECTURES.
+#-------------------------------------------------------------------------------
+if (NOT CMAKE_OSX_ARCHITECTURES)
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif()
+
 project(SignalFlow C CXX)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Develop)
@@ -9,15 +19,6 @@ endif()
 #-------------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MACOSX_RPATH 1)
-
-#-------------------------------------------------------------------------------
-# By default, build a universal library on Apple.
-# For a faster build, select a single architecture by defining the
-# environmental variable CMAKE_OSX_ARCHITECTURES.
-#-------------------------------------------------------------------------------
-if (NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
-endif()
 
 #-------------------------------------------------------------------------------
 # Shared compiler flags.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_MACOSX_RPATH 1)
 # environmental variable CMAKE_OSX_ARCHITECTURES.
 #-------------------------------------------------------------------------------
 if (NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_OSX_ARCHITECTURES "${ARCHS_STANDARD}")
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit 3ec40fc30ada41364298e70267366d2aa6dbff43 and fixes the undefined symbols issue when building on intel.

By moving `set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")` before `project(SignalFlow C CXX)` (as per [docs](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html)) the library symbols can be found.

ping @ideoforms 


The previous commit has an error, it uses `${ARCHS_STANDARD}` instead of the correct
value of `$(ARCHS_STANDARD)`. The reason it still worked was `${ARCHS_STANDARD}`
is a CMake variable, and is set to `""` by default.

The parentheses version will work correctly if using Xcode or Makefiles as your
build system, but fails with ninja (default build system for CLion).
