### PR TITLE
Documentation: Fixing comment wrapping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/docs/library/control/mousedown/example-0.py
+++ b/docs/library/control/mousedown/example-0.py
@@ -2,7 +2,8 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# When the left mouse button is clicked, as detected by MouseDown(), an LFO is applied to the oscillator's frequency.
+# When the left mouse button is clicked, as detected by MouseDown(), an LFO is 
+# applied to the oscillator's frequency.
 #-------------------------------------------------------------------------------
 lfo = SineLFO(5, 100, 600)
 frequency = If(MouseDown(), lfo, 100)

--- a/docs/library/control/mousedown/example-1.py
+++ b/docs/library/control/mousedown/example-1.py
@@ -2,7 +2,10 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# A simple wobbling synthesiser controlled using the mouse. When the mouse is clicked, as detected by MouseDown(), an LFO is activated and affects the oscillator's frequency. MouseX position changes the rate of the LFO. MouseY position changes the upper frequency limit, affecting pitch.
+# A simple wobbling synthesiser controlled using the mouse. When the mouse is 
+# clicked, as detected by MouseDown(), an LFO is activated and affects the 
+# oscillator's frequency. MouseX position changes the rate of the LFO. MouseY 
+# position changes the upper frequency limit, affecting pitch.
 #-------------------------------------------------------------------------------
 rate = MouseX() * 10
 upper_limit = MouseY() * 1500

--- a/docs/library/control/mousex/example-0.py
+++ b/docs/library/control/mousex/example-0.py
@@ -2,7 +2,8 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# Using the MouseX position to change the rate of an LFO, which is modulating an oscillator's frequency
+# Using the MouseX position to change the rate of an LFO, which is modulating an
+# oscillator's frequency.
 #-------------------------------------------------------------------------------
 lfo_rate = MouseX() * 10
 frequency = SineLFO(lfo_rate, 100, 600)

--- a/docs/library/control/mousex/example-1.py
+++ b/docs/library/control/mousex/example-1.py
@@ -2,7 +2,10 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# A simple wobbling synthesiser controlled using the mouse. When the mouse is clicked, as detected by MouseDown(), an LFO is activated and affects the oscillator's frequency. MouseX position changes the rate of the LFO. MouseY position changes the upper frequency limit, affecting pitch.
+# A simple wobbling synthesiser controlled using the mouse. When the mouse is 
+# clicked, as detected by MouseDown(), an LFO is activated and affects the 
+# oscillator's frequency. MouseX position changes the rate of the LFO. MouseY 
+# position changes the upper frequency limit, affecting pitch.
 #-------------------------------------------------------------------------------
 rate = MouseX() * 10
 upper_limit = MouseY() * 1500

--- a/docs/library/control/mousey/example-1.py
+++ b/docs/library/control/mousey/example-1.py
@@ -2,7 +2,10 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# A simple wobbling synthesiser controlled using the mouse. When the mouse is clicked, as detected by MouseDown(), an LFO is activated and affects the oscillator's frequency. MouseX position changes the rate of the LFO. MouseY position changes the upper frequency limit, affecting pitch.
+# A simple wobbling synthesiser controlled using the mouse. When the mouse is 
+# clicked, as detected by MouseDown(), an LFO is activated and affects the 
+# oscillator's frequency. MouseX position changes the rate of the LFO. MouseY 
+# position changes the upper frequency limit, affecting pitch.
 #-------------------------------------------------------------------------------
 rate = MouseX() * 10
 upper_limit = MouseY() * 1500

--- a/docs/library/envelope/line/example-0.py
+++ b/docs/library/envelope/line/example-0.py
@@ -2,7 +2,8 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# Using a line to control the gain of an oscillator, emulating a sidechain ducking effect.
+# Using a line to control the gain of an oscillator, emulating a sidechain 
+# ducking effect.
 #-------------------------------------------------------------------------------
 clock = Impulse(frequency=1.0)
 line = Line(0.0, 0.5, 0.5, False, clock)

--- a/docs/library/sequencing/clockdivider/example-0.py
+++ b/docs/library/sequencing/clockdivider/example-0.py
@@ -2,7 +2,9 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# Using a ClockDivider to create rhythms related to the main clock. Here the oscillator in the left channel is heard on every tick of the clock. The oscillator in the right channel is heard every 3 ticks of the clock.
+# Using a ClockDivider to create rhythms related to the main clock. Here the 
+# oscillator panned left is heard on every tick of the clock. The oscillator 
+# panned right is heard every 3 ticks of the clock.
 #-------------------------------------------------------------------------------
 clock = Impulse(2.0)
 divided_clock = ClockDivider(clock, 3)

--- a/docs/library/sequencing/sequence/example-0.py
+++ b/docs/library/sequencing/sequence/example-0.py
@@ -2,7 +2,8 @@ from signalflow import *
 graph = AudioGraph()
 
 #-------------------------------------------------------------------------------
-# Creating a sequence using the MIDI note values of a C Major scale, starting on middle C.
+# Creating a sequence using the MIDI note values of a C Major scale, starting on
+# middle C.
 #-------------------------------------------------------------------------------
 clock = Impulse(2.0)
 sequence = Sequence([ 60, 62, 64, 65, 67, 69, 71, 72 ], clock)


### PR DESCRIPTION
Limiting each line of comments to 80 characters so that they wrap properly.